### PR TITLE
CMakeLists.txt: do not completely overwrite CMAKE_CXX_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ pkg_check_modules(LIBCONFIG REQUIRED
 
 include(GNUInstallDirs REQUIRED)
 
-set(CMAKE_CXX_FLAGS "-DQT_NO_KEYWORDS -fno-exceptions")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DQT_NO_KEYWORDS -fno-exceptions")
 
 if(USE_QT5)
   set(QTX_INCLUDE_DIRS "")


### PR DESCRIPTION
fixes:

| /usr/include/qt5/QtCore/qcompilerdetection.h:882:20: fatal error: utility: No such file or directory

Signed-off-by: Andreas Müller <schnitzeltony@googlemail.com>