### PR TITLE
Set default opacity for active windows to 1

### DIFF
--- a/compton.conf.example
+++ b/compton.conf.example
@@ -19,7 +19,7 @@ shadow-ignore-shaped = false;
 # Opacity
 menu-opacity = 0.8;
 inactive-opacity = 0.8;
-active-opacity = 0.8;
+active-opacity = 1.0;
 frame-opacity = 0.7;
 inactive-opacity-override = false;
 alpha-step = 0.06;


### PR DESCRIPTION
Improves first user experience.