### PR TITLE
Add RadioButtons for setting the rendering backend

### DIFF
--- a/maindialog.h
+++ b/maindialog.h
@@ -47,7 +47,8 @@ private:
   void configSetInt(const char* key, int val);
   void configSetFloat(const char* key, double val);
   void configSetBool(const char* key, bool val);
-  
+  void configSetString(const char* key, const char* val);
+
 private Q_SLOTS:
   void onButtonToggled(bool checked);
   void onSpinValueChanged(double d);
@@ -55,6 +56,7 @@ private Q_SLOTS:
   void onDialogButtonClicked(QAbstractButton* button);
   void onColorButtonClicked();
   void onAboutButtonClicked();
+  void onRadioGroupToggled(bool checked);
 
 private:
   Ui::MainDialog* ui;

--- a/maindialog.ui
+++ b/maindialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>493</width>
-    <height>371</height>
+    <width>569</width>
+    <height>424</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -356,11 +356,39 @@
        <string>Other</string>
       </attribute>
       <layout class="QFormLayout" name="formLayout_4">
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_14">
-         <property name="text">
-          <string>Not implemented yet</string>
+       <item row="0" column="1">
+        <widget class="QGroupBox" name="backend">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
+         <property name="title">
+          <string>Rendering backend</string>
+         </property>
+         <property name="flat">
+          <bool>false</bool>
+         </property>
+         <property name="checkable">
+          <bool>false</bool>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QRadioButton" name="backend_xrender">
+            <property name="text">
+             <string>X Render</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="backend_glx">
+            <property name="text">
+             <string>GLX (OpenGL)</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
       </layout>


### PR DESCRIPTION
These changes resolve #53

1. Add a new method for writing string configuration settings.
2. Add a slot method for handling the toggle signal of _grouped(!) radio buttons_.
3. Reading the settings will differ between grouped and not grouped radio buttons.
3.1. Not grouped radio buttons will be handled like normal check boxes.
3.2. Grouped radio buttons use the `objectName` of the surrounding group box as key name.
4. Add a group box with two radio buttons to the last tab `Other`, for setting the rendering backend.
