### PR TITLE
Add categories and change icon in desktop file

### DIFF
--- a/compton-conf.desktop.in
+++ b/compton-conf.desktop.in
@@ -5,7 +5,7 @@ GenericName=Compton Configuration
 Comment=Configure Compton window effects
 TryExec=compton-conf
 Exec=compton-conf
-Icon=preferences-system-windows
+Icon=compton
 Categories=Settings;DesktopSettings;Qt;LXQt;X-XFCE-SettingsDialog;X-XFCE-PersonalSettings;X-GNOME-PersonalSettings;
 
 #TRANSLATIONS_DIR=translations

--- a/compton-conf.desktop.in
+++ b/compton-conf.desktop.in
@@ -6,6 +6,6 @@ Comment=Configure Compton window effects
 TryExec=compton-conf
 Exec=compton-conf
 Icon=compton
-Categories=Settings;DesktopSettings;Qt;LXQt;X-XFCE-SettingsDialog;X-XFCE-PersonalSettings;X-GNOME-PersonalSettings;
+Categories=Settings;DesktopSettings;Qt;LXQt;X-XFCE-SettingsDialog;X-XFCE-PersonalSettings;
 
 #TRANSLATIONS_DIR=translations

--- a/compton-conf.desktop.in
+++ b/compton-conf.desktop.in
@@ -6,6 +6,6 @@ Comment=Configure Compton window effects
 TryExec=compton-conf
 Exec=compton-conf
 Icon=preferences-system-windows
-Categories=Settings;DesktopSettings;Qt;LXQt;
+Categories=Settings;DesktopSettings;Qt;LXQt;X-XFCE-SettingsDialog;X-XFCE-PersonalSettings;X-GNOME-PersonalSettings;
 
 #TRANSLATIONS_DIR=translations


### PR DESCRIPTION
- Add categories for Xfce and Gnome
so that they are displayed in the settings managers
- Use default icon of compton for compton-conf
compton-conf is always installed together with compton,
so the default icon of compton is always present

resolves #25